### PR TITLE
Add .banana command

### DIFF
--- a/data/food/banana.json
+++ b/data/food/banana.json
@@ -1,0 +1,49 @@
+{
+    "templates": [
+        "gives {user} {size} {ripeness} banana{extra}."
+    ],
+    "parts": {
+        "size": [
+            "a tiny",
+            "a small",
+            "a regular",
+            "a large",
+            "an enormous",
+            "a colossal",
+            "a bite-sized",
+            "a perfectly-sized"
+        ],
+        "ripeness": [
+            "green",
+            "slightly underripe",
+            "perfectly ripe",
+            "spotted",
+            "golden",
+            "overripe",
+            "brown-spotted",
+            "mushy"
+        ],
+        "extra": [
+            "",
+            " from Ecuador",
+            " from Costa Rica",
+            " from Colombia",
+            " from the Philippines",
+            " from Honduras",
+            " organic",
+            " fair trade certified",
+            " straight from the tree",
+            " still in its peel",
+            " pre-sliced",
+            " frozen",
+            " dipped in chocolate",
+            " topped with whipped cream",
+            " alongside some peanut butter",
+            " with a side of yogurt",
+            " in a fruit salad",
+            " wrapped in bacon",
+            " caramelized",
+            " flambeed"
+        ]
+    }
+}

--- a/plugins/foods.py
+++ b/plugins/foods.py
@@ -32,6 +32,7 @@ BASIC_FOOD = (
     BasicFood("nugget", "nuggets"),
     BasicFood("pie", "pie"),
     BasicFood("brekkie", "brekkie", "brekkie", "brekky"),
+    BasicFood("banana", "a banana"),
     BasicFood("icecream", "icecream"),
     BasicFood("doobie", "a doobie"),
     BasicFood("wine", "wine"),


### PR DESCRIPTION
## Summary

Adds a new `.banana <user>` food command, similar to the existing `.pizza` command.

## Changes

- Added `banana` to `BASIC_FOOD` list in `plugins/foods.py`
- Created `data/food/banana.json` with templates for:
  - Random sizes (tiny to colossal)
  - Ripeness levels (green to mushy)
  - Fun extras (origins, toppings, preparations)

## Usage

```
<user> .banana alice
* bot gives alice a perfectly ripe banana from Ecuador
```

## Testing

- Follows the same pattern as existing food commands (pizza, taco, etc.)
- Uses the standard `TextGenerator` template system

---

*PR created by OpenClaw*