### PR TITLE
Improve chat_history usage propensity in agent instructions

### DIFF
--- a/plugins/agent.py
+++ b/plugins/agent.py
@@ -89,7 +89,7 @@ AGENT_INSTRUCTIONS = (
     "Call multiple tools in parallel when independent. "
     "Use the chat_history tool when the request refers to something said earlier or needs channel context. "
     "When a message contains an image URL (jpg/png/gif/webp/imgur/i.redd.it etc.), use describe_image to see it. "
-    "Keep your final answer concise â IRC lines are short. "
+    "Keep your final answer concise Ã¢ÂÂ IRC lines are short. "
     "When a tool returns raw text, extract and summarise the key information."
 )
 
@@ -184,7 +184,7 @@ def _build_tool(cmd_name: str, cmd_hook) -> FunctionTool:
             cmd_prefix=".",
         )
         # launch() runs sieves (rate_limit, check_disabled, check_acls).
-        # internal_launch() would skip them â we want them enforced per tool call.
+        # internal_launch() would skip them Ã¢ÂÂ we want them enforced per tool call.
         ok = await irc_event.bot.plugin_manager.launch(cmd_hook, capture)
         if not ok:
             return f"(command .{cmd_name} errored)"
@@ -306,17 +306,17 @@ def _format_answer(text: str, cfg: dict) -> list[str]:
     return [formatting.truncate(collapsed, max_chars)]
 
 
-TEST_MARKER_XYZ(event, prompt: str) -> None:
+async def _run_agent(event, prompt: str) -> None:
     bot = event.bot
     cfg = bot.config.get("plugins", {}).get("agent", {}) or {}
     logger.info("agent: _run_agent called, prompt=%r, cfg_keys=%s", prompt, list(cfg.keys()) if cfg else "EMPTY")
     if not cfg or not cfg.get("enabled", False) or not cfg.get("backends"):
-        logger.info("agent: aborting â enabled=%s backends=%s", cfg.get("enabled") if cfg else "N/A", bool(cfg.get("backends")) if cfg else "N/A")
+        logger.info("agent: aborting Ã¢ÂÂ enabled=%s backends=%s", cfg.get("enabled") if cfg else "N/A", bool(cfg.get("backends")) if cfg else "N/A")
         return
 
     enabled_chans = cfg.get("enabled_channels") or []
     if enabled_chans and event.chan not in enabled_chans:
-        logger.info("agent: aborting â chan %s not in enabled_channels %s", event.chan, enabled_chans)
+        logger.info("agent: aborting Ã¢ÂÂ chan %s not in enabled_channels %s", event.chan, enabled_chans)
         return
 
     prompt = (prompt or "").strip()

--- a/plugins/agent.py
+++ b/plugins/agent.py
@@ -20,7 +20,7 @@ from cloudbot import hook
 from cloudbot.event import CommandEvent
 from cloudbot.util import formatting
 from cloudbot.util.typing import start_typing_for_command, stop_typing_for_command
-TEST_MARKER3 CUSTOM_TOOLS, upload_markdown_paste
+from plugins.agent_tools import CUSTOM_TOOLS, upload_markdown_paste
 
 logger = logging.getLogger("cloudbot")
 
@@ -89,7 +89,7 @@ AGENT_INSTRUCTIONS = (
     "Call multiple tools in parallel when independent. "
     "Use the chat_history tool when the request refers to something said earlier or needs channel context. "
     "When a message contains an image URL (jpg/png/gif/webp/imgur/i.redd.it etc.), use describe_image to see it. "
-    "Keep your final answer concise ÃÂ¢ÃÂÃÂ IRC lines are short. "
+    "Keep your final answer concise ÃÂÃÂ¢ÃÂÃÂÃÂÃÂ IRC lines are short. "
     "When a tool returns raw text, extract and summarise the key information."
 )
 
@@ -184,7 +184,7 @@ def _build_tool(cmd_name: str, cmd_hook) -> FunctionTool:
             cmd_prefix=".",
         )
         # launch() runs sieves (rate_limit, check_disabled, check_acls).
-        # internal_launch() would skip them ÃÂ¢ÃÂÃÂ we want them enforced per tool call.
+        # internal_launch() would skip them ÃÂÃÂ¢ÃÂÃÂÃÂÃÂ we want them enforced per tool call.
         ok = await irc_event.bot.plugin_manager.launch(cmd_hook, capture)
         if not ok:
             return f"(command .{cmd_name} errored)"
@@ -311,12 +311,12 @@ async def _run_agent(event, prompt: str) -> None:
     cfg = bot.config.get("plugins", {}).get("agent", {}) or {}
     logger.info("agent: _run_agent called, prompt=%r, cfg_keys=%s", prompt, list(cfg.keys()) if cfg else "EMPTY")
     if not cfg or not cfg.get("enabled", False) or not cfg.get("backends"):
-        logger.info("agent: aborting ÃÂ¢ÃÂÃÂ enabled=%s backends=%s", cfg.get("enabled") if cfg else "N/A", bool(cfg.get("backends")) if cfg else "N/A")
+        logger.info("agent: aborting ÃÂÃÂ¢ÃÂÃÂÃÂÃÂ enabled=%s backends=%s", cfg.get("enabled") if cfg else "N/A", bool(cfg.get("backends")) if cfg else "N/A")
         return
 
     enabled_chans = cfg.get("enabled_channels") or []
     if enabled_chans and event.chan not in enabled_chans:
-        logger.info("agent: aborting ÃÂ¢ÃÂÃÂ chan %s not in enabled_channels %s", event.chan, enabled_chans)
+        logger.info("agent: aborting ÃÂÃÂ¢ÃÂÃÂÃÂÃÂ chan %s not in enabled_channels %s", event.chan, enabled_chans)
         return
 
     prompt = (prompt or "").strip()

--- a/plugins/agent.py
+++ b/plugins/agent.py
@@ -20,7 +20,7 @@ from cloudbot import hook
 from cloudbot.event import CommandEvent
 from cloudbot.util import formatting
 from cloudbot.util.typing import start_typing_for_command, stop_typing_for_command
-from plugins.agent_tools import CUSTOM_TOOLS, upload_markdown_paste
+TEST_MARKER3 CUSTOM_TOOLS, upload_markdown_paste
 
 logger = logging.getLogger("cloudbot")
 
@@ -89,7 +89,7 @@ AGENT_INSTRUCTIONS = (
     "Call multiple tools in parallel when independent. "
     "Use the chat_history tool when the request refers to something said earlier or needs channel context. "
     "When a message contains an image URL (jpg/png/gif/webp/imgur/i.redd.it etc.), use describe_image to see it. "
-    "Keep your final answer concise Ã¢ÂÂ IRC lines are short. "
+    "Keep your final answer concise ÃÂ¢ÃÂÃÂ IRC lines are short. "
     "When a tool returns raw text, extract and summarise the key information."
 )
 
@@ -184,7 +184,7 @@ def _build_tool(cmd_name: str, cmd_hook) -> FunctionTool:
             cmd_prefix=".",
         )
         # launch() runs sieves (rate_limit, check_disabled, check_acls).
-        # internal_launch() would skip them Ã¢ÂÂ we want them enforced per tool call.
+        # internal_launch() would skip them ÃÂ¢ÃÂÃÂ we want them enforced per tool call.
         ok = await irc_event.bot.plugin_manager.launch(cmd_hook, capture)
         if not ok:
             return f"(command .{cmd_name} errored)"
@@ -311,12 +311,12 @@ async def _run_agent(event, prompt: str) -> None:
     cfg = bot.config.get("plugins", {}).get("agent", {}) or {}
     logger.info("agent: _run_agent called, prompt=%r, cfg_keys=%s", prompt, list(cfg.keys()) if cfg else "EMPTY")
     if not cfg or not cfg.get("enabled", False) or not cfg.get("backends"):
-        logger.info("agent: aborting Ã¢ÂÂ enabled=%s backends=%s", cfg.get("enabled") if cfg else "N/A", bool(cfg.get("backends")) if cfg else "N/A")
+        logger.info("agent: aborting ÃÂ¢ÃÂÃÂ enabled=%s backends=%s", cfg.get("enabled") if cfg else "N/A", bool(cfg.get("backends")) if cfg else "N/A")
         return
 
     enabled_chans = cfg.get("enabled_channels") or []
     if enabled_chans and event.chan not in enabled_chans:
-        logger.info("agent: aborting Ã¢ÂÂ chan %s not in enabled_channels %s", event.chan, enabled_chans)
+        logger.info("agent: aborting ÃÂ¢ÃÂÃÂ chan %s not in enabled_channels %s", event.chan, enabled_chans)
         return
 
     prompt = (prompt or "").strip()

--- a/plugins/agent.py
+++ b/plugins/agent.py
@@ -89,7 +89,7 @@ AGENT_INSTRUCTIONS = (
     "Call multiple tools in parallel when independent. "
     "Use the chat_history tool when the request refers to something said earlier or needs channel context. "
     "When a message contains an image URL (jpg/png/gif/webp/imgur/i.redd.it etc.), use describe_image to see it. "
-    "Keep your final answer concise — IRC lines are short. "
+    "Keep your final answer concise â IRC lines are short. "
     "When a tool returns raw text, extract and summarise the key information."
 )
 
@@ -184,7 +184,7 @@ def _build_tool(cmd_name: str, cmd_hook) -> FunctionTool:
             cmd_prefix=".",
         )
         # launch() runs sieves (rate_limit, check_disabled, check_acls).
-        # internal_launch() would skip them — we want them enforced per tool call.
+        # internal_launch() would skip them â we want them enforced per tool call.
         ok = await irc_event.bot.plugin_manager.launch(cmd_hook, capture)
         if not ok:
             return f"(command .{cmd_name} errored)"
@@ -306,17 +306,17 @@ def _format_answer(text: str, cfg: dict) -> list[str]:
     return [formatting.truncate(collapsed, max_chars)]
 
 
-async def _run_agent(event, prompt: str) -> None:
+TEST_MARKER_XYZ(event, prompt: str) -> None:
     bot = event.bot
     cfg = bot.config.get("plugins", {}).get("agent", {}) or {}
     logger.info("agent: _run_agent called, prompt=%r, cfg_keys=%s", prompt, list(cfg.keys()) if cfg else "EMPTY")
     if not cfg or not cfg.get("enabled", False) or not cfg.get("backends"):
-        logger.info("agent: aborting — enabled=%s backends=%s", cfg.get("enabled") if cfg else "N/A", bool(cfg.get("backends")) if cfg else "N/A")
+        logger.info("agent: aborting â enabled=%s backends=%s", cfg.get("enabled") if cfg else "N/A", bool(cfg.get("backends")) if cfg else "N/A")
         return
 
     enabled_chans = cfg.get("enabled_channels") or []
     if enabled_chans and event.chan not in enabled_chans:
-        logger.info("agent: aborting — chan %s not in enabled_channels %s", event.chan, enabled_chans)
+        logger.info("agent: aborting â chan %s not in enabled_channels %s", event.chan, enabled_chans)
         return
 
     prompt = (prompt or "").strip()


### PR DESCRIPTION
## Problem

The agent currently rarely uses `chat_history` / `search_history` because:

1. **System prompt is too restrictive**: The instruction says *"Use the chat_history tool when the request EXPLICITLY refers to something said earlier"* — the word "EXPLICITLY" sets a very high bar. Most follow-ups in IRC are implicit ("what about that thing?", "fix it", "can you also...").

2. **Recent chat context header is actively dismissive**: The enriched prompt preamble says *"reference only, NOT a task to continue"* and *"do not continue any prior work shown in the recent context above"*. While this prevents the bot from hijacking other users' tasks, it also creates a strong bias against looking up context at all.

3. **`_RECENT_CHAT_LINES = 6`** is too low — with 6 lines, there's barely any context, making it more likely the bot needs `chat_history` but won't reach for it.

## Proposed changes (for `cloudbot/agent/instructions.py`)

### Change 1: Soften the chat_history gating condition

**Current:**
```
Use the chat_history tool when the request EXPLICITLY refers to something said earlier and the recent context block above is not enough.
```

**Proposed:**
```
Use the chat_history tool liberally — call it when the request may reference earlier conversation, even if not explicitly stated. Examples: pronoun references ('it', 'that', 'that thing'), corrections ('no I meant...'), or any prompt where additional context would improve your answer. The recent context block above is a lightweight hint; chat_history gives the full picture when you need it.
```

### Change 2: Add a positive nudge in the "new task" preamble (in `_run_agent`)

**Current enriched prompt:**
```
This is a NEW task from {nick}. Act on the message below — do not continue any prior work shown in the recent context above.
```

**Proposed:**
```
This is a NEW task from {nick}. Act on the message below — do not continue any prior work shown in the recent context above. HOWEVER, if the user's message seems to reference something from earlier in the conversation (even vaguely), use the chat_history tool to look up context before answering.
```

### Change 3: Increase `_RECENT_CHAT_LINES` from 6 to 15

More context in the preamble means fewer situations where `chat_history` is needed for trivial follow-ups, and when it IS needed, the bot has a better starting point.

## Note

The fork used for this PR is behind `main` and doesn't have the `_build_recent_chat_snippet` / `_RECENT_CHAT_LINES` code yet. The actual code changes should be applied to `main`'s versions of:
- `cloudbot/agent/instructions.py` (AGENT_INSTRUCTIONS string)
- `plugins/agent.py` (lines ~500 `_RECENT_CHAT_LINES`, ~522 `_build_recent_chat_snippet` header, ~760-766 enriched prompt)