### PR TITLE
fix: .etree and .tax return lists instead of calling reply() per line

### DIFF
--- a/plugins/etymology.py
+++ b/plugins/etymology.py
@@ -22,7 +22,10 @@ from cloudbot.util.web import get_session
 @hook.command("etree")
 def etymology_tree(text):
     """<word> - retrieves etymolocial tree of <word>"""
-    return str(ety.tree(text.strip())).split("\n")
+    tree = ety.tree(text.strip())
+    if not tree:
+        return [f"No etymology tree found for {text} :("]
+    return tree.split("\n")
 
 
 @hook.command("e", "etymology")

--- a/plugins/etymology.py
+++ b/plugins/etymology.py
@@ -20,11 +20,9 @@ from cloudbot.util.web import get_session
 
 
 @hook.command("etree")
-def etymology_tree(nick, text, reply):
+def etymology_tree(text):
     """<word> - retrieves etymolocial tree of <word>"""
-    # pager = CommandPager.from_multiline_string(str(ety.tree(text.strip())))
-    for page in str(ety.tree(text.strip())).split("\n"):
-        reply(page)
+    return str(ety.tree(text.strip())).split("\n")
 
 
 @hook.command("e", "etymology")

--- a/plugins/taxonomy.py
+++ b/plugins/taxonomy.py
@@ -274,7 +274,7 @@ def get_taxonomy_from_gbif(species_name: str) -> dict[str, str | None] | None:
 
 
 @hook.command("taxonomy", "tax")
-def taxonomy(text: str, reply) -> None:
+def taxonomy(text: str):
     """<species> [-s|--simple] - retrieves taxonomic classification tree for <species>"""
 
     if not text or not text.strip():

--- a/plugins/taxonomy.py
+++ b/plugins/taxonomy.py
@@ -278,16 +278,14 @@ def taxonomy(text: str):
     """<species> [-s|--simple] - retrieves taxonomic classification tree for <species>"""
 
     if not text or not text.strip():
-        reply("Please provide a species name")
-        return
+        return ["Please provide a species name"]
 
     parts = text.strip().split()
     simple_mode = "--simple" in parts or "-s" in parts
     species_name = " ".join(p for p in parts if p not in ["--simple", "-s"])
 
     if not species_name:
-        reply("Please provide a species name")
-        return
+        return ["Please provide a species name"]
 
     try:
         taxonomy_data = None

--- a/plugins/taxonomy.py
+++ b/plugins/taxonomy.py
@@ -302,13 +302,11 @@ def taxonomy(text: str, reply) -> None:
             taxonomy_data = get_taxonomy_from_gbif(species_name)
 
         if not taxonomy_data:
-            reply(f"No taxonomic data found for '{species_name}'")
-            return
+            return [f"No taxonomic data found for '{species_name}'"]
 
-        for line in build_taxonomy_tree(
+        return build_taxonomy_tree(
             taxonomy_data, show_relatives=not simple_mode
-        ):
-            reply(line)
+        )
 
     except Exception:
-        reply(f"Error retrieving taxonomy data for '{species_name}'")
+        return [f"Error retrieving taxonomy data for '{species_name}'"]


### PR DESCRIPTION
## What
- **`etymology.py` (`etree`)**: Removed `reply()` loop — now returns `list[str]` directly. Also removed unused `nick` and `reply` params from signature.
- **`taxonomy.py` (`tax`)**: Removed `reply()` loop — now returns `list[str]` from `build_taxonomy_tree()` (or single-element list with error message). Removed unused `reply` param.

## Why
Commands that produce multi-line output should return a list and let the bot framework handle pagination/rate-limiting. Calling `reply()` in a loop bypasses the framework's output handling.

## Changes
| File | Before | After |
|------|--------|-------|
| `plugins/etymology.py` | `for page in ...: reply(page)` | `return str(ety.tree(...)).split("\n")` |
| `plugins/taxonomy.py` | `for line in tree: reply(line)` | `return build_taxonomy_tree(...)` |

Replaces/closes #25 (which had the same intent but was stale).