### PR TITLE
Remove Google URL redirect parser hook plugin

### DIFF
--- a/plugins/googleurlparse.py
+++ b/plugins/googleurlparse.py
@@ -1,12 +1,1 @@
-# Removed — Google URL redirect parser disabled per PR
-# This plugin used to auto-expand Google redirect URLs in chat.
-# import re
-# from urllib.parse import unquote
-# from cloudbot import hook
-# 
-# spamurl = re.compile(r".*(((www\.)?google\.com/url\?)[^ ]+)", re.I)
-# 
-# 
-# @hook.regex(spamurl)
-# def google_url(match):
-#     ...
+# Removed — see PR #30

--- a/plugins/googleurlparse.py
+++ b/plugins/googleurlparse.py
@@ -1,25 +1,12 @@
-import re
-from urllib.parse import unquote
-
-from cloudbot import hook
-
-spamurl = re.compile(r".*(((www\.)?google\.com/url\?)[^ ]+)", re.I)
-
-
-@hook.regex(spamurl)
-def google_url(match):
-    matches = match.group(1)
-    url = matches
-
-    url = f"http://{url}"
-    out = (
-        "".join(
-            [
-                (unquote(a[4:]) if a[:4] == "url=" else "")
-                for a in url.split("&")
-            ]
-        )
-        .replace(", ,", "")
-        .strip()
-    )
-    return out
+# Removed — Google URL redirect parser disabled per PR
+# This plugin used to auto-expand Google redirect URLs in chat.
+# import re
+# from urllib.parse import unquote
+# from cloudbot import hook
+# 
+# spamurl = re.compile(r".*(((www\.)?google\.com/url\?)[^ ]+)", re.I)
+# 
+# 
+# @hook.regex(spamurl)
+# def google_url(match):
+#     ...


### PR DESCRIPTION
## Summary

Removes the `googleurlparse.py` plugin's regex hook that auto-expanded Google redirect URLs (`google.com/url?...`) in chat, displaying their decoded destination URLs as inline previews.

### What changed
- **`plugins/googleurlparse.py`**: Neutered — the `@hook.regex(spamurl)` hook and `google_url()` function are now commented out. The file is kept as a stub for reference but does nothing at runtime.

### Why
The URL preview behavior (auto-displaying resolved URLs inline) was creating clutter in channels. Modern IRC clients handle URL preview natively without bot intervention.

### Test plan
- Verify no Google redirect URLs get auto-expanded after this plugin loads
- Confirm no regressions to other URL-related commands (`.urls`, `.urlsn`)